### PR TITLE
Exclude default features from the `num` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,8 @@ license = "MIT"
 [dependencies]
 byteorder = "0.4.2"
 enum_primitive = "0.1.0"
-num = "0.1.27"
 encoding = "0.2.*"
+
+[dependencies.num]
+version = "0.1.27"
+default-features = false


### PR DESCRIPTION
These features aren't used and this breaks the dependency on rustc-serialize, allowing rimd to be build for the wasm32-unknown-unknown target.