### PR TITLE
Make some utils public and #[derive(FromPrimitive)], use num-traits instead of num crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["midi", "smf", "music", "audio", "mid"]
 license = "MIT"
 
 [dependencies]
-byteorder = "0.4.2"
-enum_primitive = "0.1.0"
-num = "0.1.27"
+byteorder = "1.2"
 encoding = "0.2.*"
+num-traits = "0.2"
+num-derive = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ pub use midi:: {
     Status,
     MidiError,
     MidiMessage,
+    STATUS_MASK,
+    CHANNEL_MASK,
 };
 
 pub use meta:: {
@@ -277,11 +279,11 @@ impl SMF {
                     time += event.vtime;
                     match event.event {
                         Event::Midi(ref msg) if msg.channel().is_some() => {
-                            let mut events = &mut tracks[msg.channel().unwrap() as usize + 1];
+                            let events = &mut tracks[msg.channel().unwrap() as usize + 1];
                             events.push(TrackEvent {vtime: time, event: event.event.clone()});
                         }
                         /*MidiEvent::Meta(ref msg) if [
-                            MetaCommand::MIDIChannelPrefixAssignment, 
+                            MetaCommand::MIDIChannelPrefixAssignment,
                             MetaCommand::MIDIPortPrefixAssignment,
                             MetaCommand::SequenceOrTrackName,
                             MetaCommand::InstrumentName,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@
 //! http://cs.fit.edu/~ryan/cse4051/projects/midi/midi.html#meta_event
 
 extern crate byteorder;
-#[macro_use] extern crate enum_primitive;
-extern crate num;
 extern crate encoding;
+extern crate num_traits;
+#[macro_use] extern crate num_derive;
 
 use std::error;
 use std::convert::From;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub use midi:: {
     MidiMessage,
     STATUS_MASK,
     CHANNEL_MASK,
+    make_status,
 };
 
 pub use meta:: {

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use reader::SMFReader;
 
-use num::FromPrimitive;
+use num_traits::FromPrimitive;
 
 use util::{read_byte, read_amount, latin1_decode};
 
@@ -50,8 +50,7 @@ impl fmt::Display for MetaError {
 }
 
 /// Commands that meta messages can represent
-enum_from_primitive! {
-#[derive(Clone,Copy,Debug,PartialEq,Eq,PartialOrd,Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd,Ord,  FromPrimitive)]
 pub enum MetaCommand {
     SequenceNumber = 0x00,
     TextEvent = 0x01,
@@ -70,7 +69,6 @@ pub enum MetaCommand {
     KeySignature = 0x59,
     SequencerSpecificEvent = 0x7F,
     Unknown,
-}
 }
 
 /// Meta event building and parsing.  See

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -97,6 +97,12 @@ impl Clone for MidiMessage {
 pub const STATUS_MASK: u8 = 0xF0;
 pub const CHANNEL_MASK: u8 = 0x0F;
 
+// Or in the channel bits to a status
+#[inline(always)]
+pub fn make_status(status: Status, channel: u8) -> u8 {
+    status as u8 | channel
+}
+
 impl MidiMessage {
     /// Return the status (type) of this message
     pub fn status(&self) -> Status {
@@ -133,12 +139,6 @@ impl MidiMessage {
     #[inline(always)]
     pub fn data(&self, index: usize) -> u8 {
         self.data[index]
-    }
-
-    // Or in the channel bits to a status
-    #[inline(always)]
-    fn make_status(status: Status, channel: u8) -> u8 {
-        status as u8 | channel
     }
 
     /// Create a midi message from a vector of bytes
@@ -239,14 +239,14 @@ impl MidiMessage {
     /// Create a note on message
     pub fn note_on(note: u8, velocity: u8, channel: u8) -> MidiMessage {
         MidiMessage {
-            data: vec![MidiMessage::make_status(Status::NoteOn,channel), note, velocity],
+            data: vec![make_status(Status::NoteOn,channel), note, velocity],
         }
     }
 
     /// Create a note off message
     pub fn note_off(note: u8, velocity: u8, channel: u8) -> MidiMessage {
         MidiMessage {
-            data: vec![MidiMessage::make_status(Status::NoteOff,channel), note, velocity],
+            data: vec![make_status(Status::NoteOff,channel), note, velocity],
         }
     }
 
@@ -254,7 +254,7 @@ impl MidiMessage {
     /// This message is most often sent by pressing down on the key after it "bottoms out".
     pub fn polyphonic_aftertouch(note: u8, pressure: u8, channel: u8) -> MidiMessage {
         MidiMessage {
-            data: vec![MidiMessage::make_status(Status::PolyphonicAftertouch,channel), note, pressure],
+            data: vec![make_status(Status::PolyphonicAftertouch,channel), note, pressure],
         }
     }
 
@@ -263,7 +263,7 @@ impl MidiMessage {
     /// pedals and levers. Controller numbers 120-127 are reserved as "Channel Mode Messages".
     pub fn control_change(controler: u8, data: u8, channel: u8) -> MidiMessage {
         MidiMessage {
-            data: vec![MidiMessage::make_status(Status::ControlChange,channel), controler, data],
+            data: vec![make_status(Status::ControlChange,channel), controler, data],
         }
     }
 
@@ -271,7 +271,7 @@ impl MidiMessage {
     /// This message sent when the patch number changes. `program` is the new program number.
     pub fn program_change(program: u8, channel: u8) -> MidiMessage {
         MidiMessage {
-            data: vec![MidiMessage::make_status(Status::ProgramChange,channel), program],
+            data: vec![make_status(Status::ProgramChange,channel), program],
         }
     }
 
@@ -281,7 +281,7 @@ impl MidiMessage {
     /// value (of all the current depressed keys). `pressure` is the pressure value.
     pub fn channel_aftertouch(pressure: u8, channel: u8) -> MidiMessage {
         MidiMessage {
-            data: vec![MidiMessage::make_status(Status::ChannelAftertouch,channel), pressure],
+            data: vec![make_status(Status::ChannelAftertouch,channel), pressure],
         }
     }
 
@@ -292,7 +292,7 @@ impl MidiMessage {
     /// `msb` are the most significant 7 bits.
     pub fn pitch_bend(lsb: u8, msb: u8, channel: u8) -> MidiMessage {
         MidiMessage {
-            data: vec![MidiMessage::make_status(Status::PitchBend,channel), lsb, msb],
+            data: vec![make_status(Status::PitchBend,channel), lsb, msb],
         }
     }
 

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::convert::From;
 use std::io::{Error,Read};
 
-use num::FromPrimitive;
+use num_traits::FromPrimitive;
 
 use util::read_byte;
 
@@ -50,8 +50,7 @@ impl fmt::Display for MidiError {
 
 /// The status field of a midi message indicates what midi command it
 /// represents and what channel it is on
-enum_from_primitive! {
-#[derive(Debug,PartialEq,Clone,Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, FromPrimitive)]
 pub enum Status {
     // voice
     NoteOff = 0x80,
@@ -75,7 +74,6 @@ pub enum Status {
     Stop = 0xFC,
     ActiveSensing = 0xFE, // FD also res/unused
     SystemReset = 0xFF,
-}
 }
 
 /// Midi message building and parsing.  See

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -221,7 +221,7 @@ impl MidiMessage {
             1 => { } // already read it
             2 => { ret.push(try!(read_byte(reader))); } // only need one more byte
             -1 => { return Err(MidiError::OtherErr("Don't handle variable sized yet")); }
-            -2 => { return Err(MidiError::OtherErr("Don't handle sysex yet")); }
+            -2 => { return Err(MidiError::OtherErr("Running status not permitted with meta and sysex event")); }
             _ =>  { return Err(MidiError::InvalidStatus(stat)); }
         }
         Ok(MidiMessage{data: ret})

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -94,8 +94,8 @@ impl Clone for MidiMessage {
     }
 }
 
-static STATUS_MASK: u8 = 0xF0;
-static CHANNEL_MASK: u8 = 0x0F;
+pub const STATUS_MASK: u8 = 0xF0;
+pub const CHANNEL_MASK: u8 = 0x0F;
 
 impl MidiMessage {
     /// Return the status (type) of this message


### PR DESCRIPTION
Changelog:

- support for sysex messages, with better error for running status ("Running status not permitted with meta and sysex event")
- #[derive(FromPrimitive)], use num-traits instead of num crate
- bump byteorder version
- make STATUS_MASK and CHANNEL_MASK public (and const) 
- make make_status() public 

The last 2 changes were done because I often need these symbols in my projects also.
