### PR TITLE
Use the `dyn` keyword instead of bare trait objects.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,11 +218,11 @@ impl error::Error for SMFError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
-            SMFError::MidiError(ref m) => Some(m as &error::Error),
-            SMFError::MetaError(ref m) => Some(m as &error::Error),
-            SMFError::Error(ref err) => Some(err as &error::Error),
+            SMFError::MidiError(ref m) => Some(m as &dyn error::Error),
+            SMFError::MetaError(ref m) => Some(m as &dyn error::Error),
+            SMFError::Error(ref err) => Some(err as &dyn error::Error),
             _ => None,
         }
     }
@@ -262,7 +262,7 @@ impl SMF {
     }
 
     /// Read an SMF from the given reader
-    pub fn from_reader(reader: &mut Read) -> Result<SMF,SMFError> {
+    pub fn from_reader(reader: &mut dyn Read) -> Result<SMF,SMFError> {
         SMFReader::read_smf(reader)
     }
 

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -31,9 +31,9 @@ impl error::Error for MetaError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
-            MetaError::Error(ref err) => Some(err as &error::Error),
+            MetaError::Error(ref err) => Some(err as &dyn error::Error),
             _ => None,
         }
     }
@@ -151,7 +151,7 @@ impl MetaEvent {
     }
 
     /// Extract the next meta event from a reader
-    pub fn next_event(reader: &mut Read) -> Result<MetaEvent, MetaError> {
+    pub fn next_event(reader: &mut dyn Read) -> Result<MetaEvent, MetaError> {
         let command =
             match MetaCommand::from_u8(try!(read_byte(reader))) {
                 Some(c) => {c},

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -30,9 +30,9 @@ impl error::Error for MidiError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
-            MidiError::Error(ref err) => Some(err as &error::Error),
+            MidiError::Error(ref err) => Some(err as &dyn error::Error),
             _ => None,
         }
     }
@@ -186,7 +186,7 @@ impl MidiMessage {
 
     /// Get the next midi message from the reader given that the
     /// status `stat` has just been read
-    pub fn next_message_given_status(stat: u8, reader: &mut Read) -> Result<MidiMessage, MidiError> {
+    pub fn next_message_given_status(stat: u8, reader: &mut dyn Read) -> Result<MidiMessage, MidiError> {
         let mut ret:Vec<u8> = Vec::with_capacity(3);
         ret.push(stat);
         match MidiMessage::data_bytes(stat) {
@@ -210,7 +210,7 @@ impl MidiMessage {
 
     /// Get the next midi message from the reader given that there's a running
     /// status of `stat` and that in place of a status was read `databyte`
-    pub fn next_message_running_status(stat: u8, databyte: u8, reader: &mut Read) -> Result<MidiMessage, MidiError> {
+    pub fn next_message_running_status(stat: u8, databyte: u8, reader: &mut dyn Read) -> Result<MidiMessage, MidiError> {
         let mut ret:Vec<u8> = Vec::with_capacity(3);
         ret.push(stat);
         ret.push(databyte);
@@ -226,7 +226,7 @@ impl MidiMessage {
     }
 
     /// Extract next midi message from a reader
-    pub fn next_message(reader: &mut Read) -> Result<MidiMessage,MidiError> {
+    pub fn next_message(reader: &mut dyn Read) -> Result<MidiMessage,MidiError> {
         let stat = try!(read_byte(reader));
         MidiMessage::next_message_given_status(stat,reader)
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -10,7 +10,7 @@ use util::{fill_buf, read_byte, latin1_decode};
 pub struct SMFReader;
 
 impl SMFReader {
-    fn parse_header(reader: &mut Read) -> Result<SMF,SMFError> {
+    fn parse_header(reader: &mut dyn Read) -> Result<SMF,SMFError> {
         let mut header:[u8;14] = [0;14];
         try!(fill_buf(reader,&mut header));
 
@@ -45,7 +45,7 @@ impl SMFReader {
                  division: division } )
     }
 
-    fn next_event(reader: &mut Read, laststat: u8, was_running: &mut bool) -> Result<TrackEvent,SMFError> {
+    fn next_event(reader: &mut dyn Read, laststat: u8, was_running: &mut bool) -> Result<TrackEvent,SMFError> {
         let time = try!(SMFReader::read_vtime(reader));
         let stat = try!(read_byte(reader));
 
@@ -79,7 +79,7 @@ impl SMFReader {
         }
     }
 
-    fn parse_track(reader: &mut Read) -> Result<Track,SMFError> {
+    fn parse_track(reader: &mut dyn Read) -> Result<Track,SMFError> {
         let mut res:Vec<TrackEvent> = Vec::new();
         let mut buf:[u8;4] = [0;4];
 
@@ -164,7 +164,7 @@ impl SMFReader {
 
     /// Read a variable sized value from the reader.
     /// This is usually used for the times of midi events but is used elsewhere as well.
-    pub fn read_vtime(reader: &mut Read) -> Result<u64,SMFError> {
+    pub fn read_vtime(reader: &mut dyn Read) -> Result<u64,SMFError> {
         let mut res: u64 = 0;
         let mut i = 0;
         let cont_mask = 0x80;
@@ -185,7 +185,7 @@ impl SMFReader {
     }
 
     /// Read an entire SMF file
-    pub fn read_smf(reader: &mut Read) -> Result<SMF,SMFError> {
+    pub fn read_smf(reader: &mut dyn Read) -> Result<SMF,SMFError> {
         let mut smf = SMFReader::parse_header(reader);
         match smf {
             Ok(ref mut s) => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,14 +19,14 @@ pub fn note_num_to_name(num: u32) -> String {
 }
 
 /// Read a single byte from a Reader
-pub fn read_byte(reader: &mut Read) -> Result<u8,Error> {
+pub fn read_byte(reader: &mut dyn Read) -> Result<u8,Error> {
     let mut b = [0; 1];
     try!(reader.read(&mut b));
     Ok(b[0])
 }
 
 /// Read from reader until buffer is full, or an error occurs
-pub fn fill_buf(reader: &mut Read, buf: &mut [u8]) -> Result<(),Error> {
+pub fn fill_buf(reader: &mut dyn Read, buf: &mut [u8]) -> Result<(),Error> {
     let mut read = 0;
     while read < buf.len() {
         let bytes_read = try!(reader.read(&mut buf[read..]));
@@ -40,7 +40,7 @@ pub fn fill_buf(reader: &mut Read, buf: &mut [u8]) -> Result<(),Error> {
 
 /// Read amt from reader and put result in dest.  Errors in underlying
 /// reader will cause this function to return an error
-pub fn read_amount(reader: &mut Read, dest: &mut Vec<u8>, amt: usize) -> Result<(),Error> {
+pub fn read_amount(reader: &mut dyn Read, dest: &mut Vec<u8>, amt: usize) -> Result<(),Error> {
     let start_len = dest.len();
     let mut len = start_len;
     if dest.capacity() < start_len + amt {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -95,7 +95,7 @@ impl SMFWriter {
     }
 
     // Write a variable length value.  Return number of bytes written.
-    pub fn write_vtime(val: u64, writer: &mut Write) -> Result<u32,Error> {
+    pub fn write_vtime(val: u64, writer: &mut dyn Write) -> Result<u32,Error> {
         let storage = SMFWriter::vtime_to_vec(val);
         try!(writer.write_all(&storage[..]));
         Ok(storage.len() as u32)
@@ -190,7 +190,7 @@ impl SMFWriter {
 
     // actual writing stuff below
 
-    fn write_header(&self, writer: &mut Write) -> Result<(),Error> {
+    fn write_header(&self, writer: &mut dyn Write) -> Result<(),Error> {
         try!(writer.write_all(&[0x4D,0x54,0x68,0x64]));
         try!(writer.write_u32::<BigEndian>(6));
         try!(writer.write_u16::<BigEndian>(self.format));
@@ -201,7 +201,7 @@ impl SMFWriter {
 
     /// Write out all the tracks that have been added to this
     /// SMFWriter to the passed writer
-    pub fn write_all(self, writer: &mut Write) -> Result<(),Error> {
+    pub fn write_all(self, writer: &mut dyn Write) -> Result<(),Error> {
         try!(self.write_header(writer));
         for track in self.tracks.into_iter() {
             try!(writer.write_all(&track[..]));


### PR DESCRIPTION
Use the `dyn` keyword introduced with Rust 1.27.0 (2018-06-21). Bare trait objects give a warning starting with Rust 1.37.0.