### PR TITLE
Convert from `try!()` macro to `?` operator

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -101,15 +101,9 @@ impl Ord for AbsoluteEvent {
                     (&Event::Midi(ref me),&Event::Midi(ref you)) => {
                         if      me.data(0) < you.data(0) { Ordering::Less }
                         else if me.data(0) > you.data(0) { Ordering::Greater }
-                        else {
-                            if me.data(1) < you.data(1) {
-                                Ordering::Less
-                            } else if me.data(1) > you.data(1) {
-                                Ordering::Greater
-                            } else {
-                                res
-                            }
-                        }
+                        else if me.data(1) < you.data(1) { Ordering::Less }
+                        else if me.data(1) > you.data(1) { Ordering::Greater }
+                        else { res }
                     },
                 }
             }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -15,13 +15,13 @@ pub struct AbsoluteEvent {
 impl AbsoluteEvent {
     pub fn new_midi(time: u64, midi: MidiMessage) -> AbsoluteEvent {
         AbsoluteEvent {
-            time: time,
+            time,
             event: Event::Midi(midi),
         }
     }
     pub fn new_meta(time: u64, meta: MetaEvent) -> AbsoluteEvent {
         AbsoluteEvent {
-            time: time,
+            time,
             event: Event::Meta(meta),
         }
     }
@@ -154,7 +154,7 @@ impl TrackBuilder {
                             };
                         prev_time = ev.time;
                         events.push(TrackEvent {
-                            vtime: vtime,
+                            vtime,
                             event: ev.event,
                         });
                     }
@@ -215,7 +215,7 @@ impl SMFBuilder {
             let vtime = bev.time - cur_time;
             cur_time = vtime;
             TrackEvent {
-                vtime: vtime,
+                vtime,
                 event: bev.event.clone(),
             }
         }).collect();
@@ -270,7 +270,7 @@ impl SMFBuilder {
         match self.tracks.index_mut(track).events {
             EventContainer::Heap(ref mut heap) => {
                 heap.push(AbsoluteEvent {
-                    time: time,
+                    time,
                     event: Event::Midi(msg),
                 });
             }
@@ -302,7 +302,7 @@ impl SMFBuilder {
         match self.tracks.index_mut(track).events {
             EventContainer::Heap(ref mut heap) => {
                 heap.push(AbsoluteEvent {
-                    time: time,
+                    time,
                     event: Event::Meta(event),
                 });
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,7 @@ pub struct SMF {
 impl SMF {
     /// Read an SMF file at the given path
     pub fn from_file(path: &Path) -> Result<SMF,SMFError> {
-        let mut file = try!(File::open(path));
+        let mut file = File::open(path)?;
         SMFReader::read_smf(&mut file)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,7 @@ impl SMF {
                     division: self.division,
                 };
                 for events in &mut tracks {
-                    if events.len() > 0 {
+                    if !events.is_empty() {
                         let mut time = 0;
                         for event in events.iter_mut() {
                             let tmp = event.vtime;

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -157,16 +157,16 @@ impl MetaEvent {
                 Some(c) => {c},
                 None => MetaCommand::Unknown,
             };
-        let len = match SMFReader::read_vtime(reader) {
+        let length = match SMFReader::read_vtime(reader) {
             Ok(t) => { t }
             Err(_) => { return Err(MetaError::OtherErr("Couldn't read time for meta command")); }
         };
         let mut data = Vec::new();
-        read_amount(reader,&mut data,len as usize)?;
+        read_amount(reader,&mut data,length as usize)?;
         Ok(MetaEvent{
-            command: command,
-            length: len,
-            data: data
+            command,
+            length,
+            data,
         })
     }
 
@@ -350,7 +350,7 @@ impl MetaEvent {
         MetaEvent {
             command: MetaCommand::SequencerSpecificEvent,
             length: data.len() as u64,
-            data: data,
+            data,
         }
     }
 

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -117,9 +117,9 @@ impl fmt::Display for MetaEvent {
                    MetaCommand::CuePoint => format!("CuePoint: {}", latin1_decode(&self.data)),
                    MetaCommand::MIDIChannelPrefixAssignment => format!("MIDI Channel Prefix Assignment, channel: {}", self.data[0]+1),
                    MetaCommand::MIDIPortPrefixAssignment => format!("MIDI Port Prefix Assignment, port: {}", self.data[0]),
-                   MetaCommand::EndOfTrack => format!("End Of Track"),
+                   MetaCommand::EndOfTrack => "End Of Track".to_string(),
                    MetaCommand::TempoSetting => format!("Set Tempo, microseconds/quarter note: {}", self.data_as_u64(3)),
-                   MetaCommand::SMPTEOffset => format!("SMPTEOffset"),
+                   MetaCommand::SMPTEOffset => "SMPTEOffset".to_string(),
                    MetaCommand::TimeSignature => format!("Time Signature: {}/{}, {} ticks/metronome click, {} 32nd notes/quarter note",
                                                          self.data[0],
                                                          2usize.pow(self.data[1] as u32),
@@ -132,7 +132,7 @@ impl fmt::Display for MetaEvent {
                                                             1 => "Minor",
                                                             _ => "Invalid Signature",
                                                         }),
-                   MetaCommand::SequencerSpecificEvent => format!("SequencerSpecificEvent"),
+                   MetaCommand::SequencerSpecificEvent => "SequencerSpecificEvent".to_string(),
                    MetaCommand::Unknown => format!("Unknown, length: {}", self.data.len()),
                })
     }

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -153,7 +153,7 @@ impl MetaEvent {
     /// Extract the next meta event from a reader
     pub fn next_event(reader: &mut dyn Read) -> Result<MetaEvent, MetaError> {
         let command =
-            match MetaCommand::from_u8(try!(read_byte(reader))) {
+            match MetaCommand::from_u8(read_byte(reader)?) {
                 Some(c) => {c},
                 None => MetaCommand::Unknown,
             };
@@ -162,7 +162,7 @@ impl MetaEvent {
             Err(_) => { return Err(MetaError::OtherErr("Couldn't read time for meta command")); }
         };
         let mut data = Vec::new();
-        try!(read_amount(reader,&mut data,len as usize));
+        read_amount(reader,&mut data,len as usize)?;
         Ok(MetaEvent{
             command: command,
             length: len,

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -331,7 +331,7 @@ impl fmt::Display for MidiMessage {
         else if self.data.len() == 3 {
             write!(f, "{}: [{},{}]\tchannel: {:?}", self.status(), self.data[1], self.data[2], self.channel())
         }
-        else if self.data.len() == 0 {
+        else if self.data.is_empty() {
             write!(f, "{}: [no data]\tchannel: {:?}", self.status(), self.channel())
         }
         else {

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -191,14 +191,14 @@ impl MidiMessage {
         ret.push(stat);
         match MidiMessage::data_bytes(stat) {
             0 => {}
-            1 => { ret.push(try!(read_byte(reader))); }
-            2 => { ret.push(try!(read_byte(reader)));
-                   ret.push(try!(read_byte(reader))); }
+            1 => { ret.push(read_byte(reader)?); }
+            2 => { ret.push(read_byte(reader)?);
+                   ret.push(read_byte(reader)?); }
             -1 => { return Err(MidiError::OtherErr("Don't handle variable sized yet")); }
             -2 => {
                 // skip SysEx message
                 while {
-                    let byte = try!(read_byte(reader));
+                    let byte = read_byte(reader)?;
                     ret.push(byte);
                     byte != Status::SysExEnd as u8
                 } {}
@@ -217,7 +217,7 @@ impl MidiMessage {
         match MidiMessage::data_bytes(stat) {
             0 => { panic!("Can't have zero length message with running status"); }
             1 => { } // already read it
-            2 => { ret.push(try!(read_byte(reader))); } // only need one more byte
+            2 => { ret.push(read_byte(reader)?); } // only need one more byte
             -1 => { return Err(MidiError::OtherErr("Don't handle variable sized yet")); }
             -2 => { return Err(MidiError::OtherErr("Running status not permitted with meta and sysex event")); }
             _ =>  { return Err(MidiError::InvalidStatus(stat)); }
@@ -227,7 +227,7 @@ impl MidiMessage {
 
     /// Extract next midi message from a reader
     pub fn next_message(reader: &mut dyn Read) -> Result<MidiMessage,MidiError> {
-        let stat = try!(read_byte(reader));
+        let stat = read_byte(reader)?;
         MidiMessage::next_message_given_status(stat,reader)
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -12,7 +12,7 @@ pub struct SMFReader;
 impl SMFReader {
     fn parse_header(reader: &mut dyn Read) -> Result<SMF,SMFError> {
         let mut header:[u8;14] = [0;14];
-        try!(fill_buf(reader,&mut header));
+        fill_buf(reader,&mut header)?;
 
         // skip RIFF header if present
         if header[0] == 0x52 &&
@@ -20,8 +20,8 @@ impl SMFReader {
            header[2] == 0x46 &&
            header[3] == 0x46 {
             let mut skip:[u8; 6] = [0; 6];
-            try!(fill_buf(reader, &mut skip));
-            try!(fill_buf(reader, &mut header));
+            fill_buf(reader, &mut skip)?;
+            fill_buf(reader, &mut header)?;
         }
 
         if header[0] != 0x4D ||
@@ -46,8 +46,8 @@ impl SMFReader {
     }
 
     fn next_event(reader: &mut dyn Read, laststat: u8, was_running: &mut bool) -> Result<TrackEvent,SMFError> {
-        let time = try!(SMFReader::read_vtime(reader));
-        let stat = try!(read_byte(reader));
+        let time = SMFReader::read_vtime(reader)?;
+        let stat = read_byte(reader)?;
 
         if (stat & 0x80) == 0 {
             *was_running = true;
@@ -57,7 +57,7 @@ impl SMFReader {
 
         match stat {
             0xFF => {
-                let event = try!(MetaEvent::next_event(reader));
+                let event = MetaEvent::next_event(reader)?;
                 Ok( TrackEvent {
                     vtime: time,
                     event: Event::Meta(event),
@@ -67,9 +67,9 @@ impl SMFReader {
                 let msg =
                     if (stat & 0x80) == 0 {
                         // this is a running status, so assume we have the same status as last time
-                        try!(MidiMessage::next_message_running_status(laststat,stat,reader))
+                        MidiMessage::next_message_running_status(laststat,stat,reader)?
                     } else {
-                        try!(MidiMessage::next_message_given_status(stat,reader))
+                        MidiMessage::next_message_given_status(stat,reader)?
                     };
                 Ok( TrackEvent {
                     vtime: time,
@@ -86,14 +86,14 @@ impl SMFReader {
         let mut copyright = None;
         let mut name = None;
 
-        try!(fill_buf(reader,&mut buf));
+        fill_buf(reader,&mut buf)?;
         if buf[0] != 0x4D || // "MTrk"
            buf[1] != 0x54 ||
            buf[2] != 0x72 ||
            buf[3] != 0x6B {
                return Err(SMFError::InvalidSMFFile("Invalid track magic"));
            }
-        try!(fill_buf(reader,&mut buf));
+        fill_buf(reader,&mut buf)?;
         let len =
             ((buf[0] as u32) << 24 |
              (buf[1] as u32) << 16 |
@@ -174,7 +174,7 @@ impl SMFReader {
             if i > 9 {
                 return Err(SMFError::InvalidSMFFile("Variable length value too long"));
             }
-            let next = try!(read_byte(reader));
+            let next = read_byte(reader)?;
             res |= next as u64 & val_mask;
             if (next & cont_mask) == 0 {
                 break;
@@ -190,7 +190,7 @@ impl SMFReader {
         match smf {
             Ok(ref mut s) => {
                 for _ in 0..s.tracks.capacity() {
-                    s.tracks.push(try!(SMFReader::parse_track(reader)));
+                    s.tracks.push(SMFReader::parse_track(reader)?);
                 }
             }
             _ => {}

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -40,9 +40,11 @@ impl SMFReader {
         let tracks = (header[10] as u16) << 8 | header[11] as u16;
         let division = (header[12] as i16) << 8 | header[13] as i16;
 
-        Ok(SMF { format: format,
-                 tracks: Vec::with_capacity(tracks as usize),
-                 division: division } )
+        Ok(SMF {
+            format,
+            tracks: Vec::with_capacity(tracks as usize),
+            division,
+        })
     }
 
     fn next_event(reader: &mut dyn Read, laststat: u8, was_running: &mut bool) -> Result<TrackEvent,SMFError> {
@@ -156,9 +158,9 @@ impl SMFReader {
             }
         }
         Ok(Track {
-            copyright: copyright,
-            name: name,
-            events: res
+            copyright,
+            name,
+            events: res,
         })
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -181,7 +181,7 @@ impl SMFReader {
             if (next & cont_mask) == 0 {
                 break;
             }
-            res = res << 7;
+            res <<= 7;
         }
         Ok(res)
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@
 use std::iter;
 use std::io::{Read,Error,ErrorKind};
 
-static NSTRS: &'static str = "C C#D D#E F F#G G#A A#B ";
+static NSTRS: &str = "C C#D D#E F F#G G#A A#B ";
 
 /// convert a midi note number to a name
 pub fn note_num_to_name(num: u32) -> String {

--- a/src/util.rs
+++ b/src/util.rs
@@ -74,7 +74,7 @@ pub fn latin1_decode(s: &[u8]) -> String {
         Ok(s) => s,
         Err(_) => match str::from_utf8(s) {
             Ok(s) => s.to_string(),
-            Err(_) => format!("[invalid string data]"),
+            Err(_) => "[invalid string data]".to_string(),
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,10 +7,10 @@ static NSTRS: &str = "C C#D D#E F F#G G#A A#B ";
 
 /// convert a midi note number to a name
 pub fn note_num_to_name(num: u32) -> String {
-    let oct = (num as f32 /12 as f32).floor()-1.0;
+    let oct = (num as f32 / 12_f32).floor()-1.0;
     let nmt = ((num%12)*2) as usize;
     let slice =
-        if NSTRS.as_bytes()[nmt+1] == ' ' as u8{
+        if NSTRS.as_bytes()[nmt+1] == b' ' {
             &NSTRS[nmt..(nmt+1)]
         } else {
             &NSTRS[nmt..(nmt+2)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,7 +21,7 @@ pub fn note_num_to_name(num: u32) -> String {
 /// Read a single byte from a Reader
 pub fn read_byte(reader: &mut dyn Read) -> Result<u8,Error> {
     let mut b = [0; 1];
-    try!(reader.read(&mut b));
+    reader.read(&mut b)?;
     Ok(b[0])
 }
 
@@ -29,7 +29,7 @@ pub fn read_byte(reader: &mut dyn Read) -> Result<u8,Error> {
 pub fn fill_buf(reader: &mut dyn Read, buf: &mut [u8]) -> Result<(),Error> {
     let mut read = 0;
     while read < buf.len() {
-        let bytes_read = try!(reader.read(&mut buf[read..]));
+        let bytes_read = reader.read(&mut buf[read..])?;
         if bytes_read == 0 {
             return Err(Error::new(ErrorKind::InvalidData, "file ends before it should"));
         }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -97,7 +97,7 @@ impl SMFWriter {
     // Write a variable length value.  Return number of bytes written.
     pub fn write_vtime(val: u64, writer: &mut dyn Write) -> Result<u32,Error> {
         let storage = SMFWriter::vtime_to_vec(val);
-        try!(writer.write_all(&storage[..]));
+        writer.write_all(&storage[..])?;
         Ok(storage.len() as u32)
     }
 
@@ -191,20 +191,20 @@ impl SMFWriter {
     // actual writing stuff below
 
     fn write_header(&self, writer: &mut dyn Write) -> Result<(),Error> {
-        try!(writer.write_all(&[0x4D,0x54,0x68,0x64]));
-        try!(writer.write_u32::<BigEndian>(6));
-        try!(writer.write_u16::<BigEndian>(self.format));
-        try!(writer.write_u16::<BigEndian>(self.tracks.len() as u16));
-        try!(writer.write_i16::<BigEndian>(self.ticks));
+        writer.write_all(&[0x4D,0x54,0x68,0x64])?;
+        writer.write_u32::<BigEndian>(6)?;
+        writer.write_u16::<BigEndian>(self.format)?;
+        writer.write_u16::<BigEndian>(self.tracks.len() as u16)?;
+        writer.write_i16::<BigEndian>(self.ticks)?;
         Ok(())
     }
 
     /// Write out all the tracks that have been added to this
     /// SMFWriter to the passed writer
     pub fn write_all(self, writer: &mut dyn Write) -> Result<(),Error> {
-        try!(self.write_header(writer));
+        self.write_header(writer)?;
         for track in self.tracks.into_iter() {
-            try!(writer.write_all(&track[..]));
+            writer.write_all(&track[..])?;
         }
         Ok(())
     }
@@ -213,7 +213,7 @@ impl SMFWriter {
     /// file.
     /// Warning: This will overwrite an existing file
     pub fn write_to_file(self, path: &Path) -> Result<(),Error> {
-        let mut file = try!(OpenOptions::new().write(true).truncate(true).create(true).open(path));
+        let mut file = OpenOptions::new().write(true).truncate(true).create(true).open(path)?;
         self.write_all(&mut file)
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -81,7 +81,7 @@ impl SMFWriter {
         let val_mask = 0x7F as u64;
         loop {
             let mut to_write = (cur & val_mask) as u8;
-            cur = cur >> 7;
+            cur >>= 7;
             if continuation {
                 // we're writing a continuation byte, so set the bit
                 to_write |= cont_mask;
@@ -147,7 +147,7 @@ impl SMFWriter {
             let lbyte = (*length & 0xFF) as u8;
             // 7-i because smf is big endian and we want to put this in bytes 4-7
             vec[7-i] = lbyte;
-            *length = (*length)>>8;
+            *length >>= 8;
         }
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -35,7 +35,7 @@ impl SMFWriter {
     pub fn new_with_division(ticks: i16) -> SMFWriter {
         SMFWriter {
             format: 1,
-            ticks: ticks,
+            ticks,
             tracks: Vec::new(),
         }
     }
@@ -45,7 +45,7 @@ impl SMFWriter {
     pub fn new_with_division_and_format(format: SMFFormat, ticks: i16) -> SMFWriter {
         SMFWriter {
             format: format as u16,
-            ticks: ticks,
+            ticks,
             tracks: Vec::new(),
         }
     }


### PR DESCRIPTION
See https://doc.rust-lang.org/std/macro.try.html for context.  The
`try!()` macro was replaced by the more succinct `?` operator.

This represents a step toward matching modern Rust style and fixing issues enumerated in https://github.com/RustAudio/rimd/issues/16