### PR TITLE
Update to num-traits=0.2.14 and num-derive=0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rimd"
 description = "Library for handling Midi and reading and writing Standard Midi Files in Rust"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Nick Lanham <nick@afternight.org>"]
 homepage = "https://github.com/RustAudio/rimd"
 repository = "https://github.com/RustAudio/rimd"
@@ -13,5 +13,5 @@ license = "MIT"
 [dependencies]
 byteorder = "1.3.2"
 encoding = "0.2.*"
-num-traits = "0.2.8"
-num-derive = "0.2.5"
+num-traits = "0.2.14"
+num-derive = "0.3.3"


### PR DESCRIPTION
This brings compatibility with up to date as of December 7th, 2020