### PR TITLE
Fix many of the Rust Clippy warnings and update Contributorship

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rimd"
 description = "Library for handling Midi and reading and writing Standard Midi Files in Rust"
 version = "0.0.3"
-authors = ["Nick Lanham <nick@afternight.org>"]
+authors = ["Nick Lanham <nick@afternight.org>", "Alex Kesling <alex@kesling.co>"]
 homepage = "https://github.com/RustAudio/rimd"
 repository = "https://github.com/RustAudio/rimd"
 documentation = "https://nicklan.github.io/rimd/target/doc/rimd/index.html"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Nick Lanham
+Copyright (c) 2020 Alex Kesling
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -101,15 +101,9 @@ impl Ord for AbsoluteEvent {
                     (&Event::Midi(ref me),&Event::Midi(ref you)) => {
                         if      me.data(0) < you.data(0) { Ordering::Less }
                         else if me.data(0) > you.data(0) { Ordering::Greater }
-                        else {
-                            if me.data(1) < you.data(1) {
-                                Ordering::Less
-                            } else if me.data(1) > you.data(1) {
-                                Ordering::Greater
-                            } else {
-                                res
-                            }
-                        }
+                        else if me.data(1) < you.data(1) { Ordering::Less }
+                        else if me.data(1) > you.data(1) { Ordering::Greater }
+                        else { res }
                     },
                 }
             }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -15,13 +15,13 @@ pub struct AbsoluteEvent {
 impl AbsoluteEvent {
     pub fn new_midi(time: u64, midi: MidiMessage) -> AbsoluteEvent {
         AbsoluteEvent {
-            time: time,
+            time,
             event: Event::Midi(midi),
         }
     }
     pub fn new_meta(time: u64, meta: MetaEvent) -> AbsoluteEvent {
         AbsoluteEvent {
-            time: time,
+            time,
             event: Event::Meta(meta),
         }
     }
@@ -154,7 +154,7 @@ impl TrackBuilder {
                             };
                         prev_time = ev.time;
                         events.push(TrackEvent {
-                            vtime: vtime,
+                            vtime,
                             event: ev.event,
                         });
                     }
@@ -215,7 +215,7 @@ impl SMFBuilder {
             let vtime = bev.time - cur_time;
             cur_time = vtime;
             TrackEvent {
-                vtime: vtime,
+                vtime,
                 event: bev.event.clone(),
             }
         }).collect();
@@ -270,7 +270,7 @@ impl SMFBuilder {
         match self.tracks.index_mut(track).events {
             EventContainer::Heap(ref mut heap) => {
                 heap.push(AbsoluteEvent {
-                    time: time,
+                    time,
                     event: Event::Midi(msg),
                 });
             }
@@ -302,7 +302,7 @@ impl SMFBuilder {
         match self.tracks.index_mut(track).events {
             EventContainer::Heap(ref mut heap) => {
                 heap.push(AbsoluteEvent {
-                    time: time,
+                    time,
                     event: Event::Meta(event),
                 });
             }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -74,10 +74,6 @@ impl PartialEq for AbsoluteEvent {
             false
         }
     }
-
-    fn ne(&self, other: &AbsoluteEvent) -> bool {
-        !(self.eq(other))
-    }
 }
 
 // Implement `Ord` and sort messages by time

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,7 @@ impl SMF {
                     division: self.division,
                 };
                 for events in &mut tracks {
-                    if events.len() > 0 {
+                    if !events.is_empty() {
                         let mut time = 0;
                         for event in events.iter_mut() {
                             let tmp = event.vtime;

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -157,16 +157,16 @@ impl MetaEvent {
                 Some(c) => {c},
                 None => MetaCommand::Unknown,
             };
-        let len = match SMFReader::read_vtime(reader) {
+        let length = match SMFReader::read_vtime(reader) {
             Ok(t) => { t }
             Err(_) => { return Err(MetaError::OtherErr("Couldn't read time for meta command")); }
         };
         let mut data = Vec::new();
-        read_amount(reader,&mut data,len as usize)?;
+        read_amount(reader,&mut data,length as usize)?;
         Ok(MetaEvent{
-            command: command,
-            length: len,
-            data: data
+            command,
+            length,
+            data,
         })
     }
 
@@ -350,7 +350,7 @@ impl MetaEvent {
         MetaEvent {
             command: MetaCommand::SequencerSpecificEvent,
             length: data.len() as u64,
-            data: data,
+            data,
         }
     }
 

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -117,9 +117,9 @@ impl fmt::Display for MetaEvent {
                    MetaCommand::CuePoint => format!("CuePoint: {}", latin1_decode(&self.data)),
                    MetaCommand::MIDIChannelPrefixAssignment => format!("MIDI Channel Prefix Assignment, channel: {}", self.data[0]+1),
                    MetaCommand::MIDIPortPrefixAssignment => format!("MIDI Port Prefix Assignment, port: {}", self.data[0]),
-                   MetaCommand::EndOfTrack => format!("End Of Track"),
+                   MetaCommand::EndOfTrack => "End Of Track".to_string(),
                    MetaCommand::TempoSetting => format!("Set Tempo, microseconds/quarter note: {}", self.data_as_u64(3)),
-                   MetaCommand::SMPTEOffset => format!("SMPTEOffset"),
+                   MetaCommand::SMPTEOffset => "SMPTEOffset".to_string(),
                    MetaCommand::TimeSignature => format!("Time Signature: {}/{}, {} ticks/metronome click, {} 32nd notes/quarter note",
                                                          self.data[0],
                                                          2usize.pow(self.data[1] as u32),
@@ -132,7 +132,7 @@ impl fmt::Display for MetaEvent {
                                                             1 => "Minor",
                                                             _ => "Invalid Signature",
                                                         }),
-                   MetaCommand::SequencerSpecificEvent => format!("SequencerSpecificEvent"),
+                   MetaCommand::SequencerSpecificEvent => "SequencerSpecificEvent".to_string(),
                    MetaCommand::Unknown => format!("Unknown, length: {}", self.data.len()),
                })
     }

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -331,7 +331,7 @@ impl fmt::Display for MidiMessage {
         else if self.data.len() == 3 {
             write!(f, "{}: [{},{}]\tchannel: {:?}", self.status(), self.data[1], self.data[2], self.channel())
         }
-        else if self.data.len() == 0 {
+        else if self.data.is_empty() {
             write!(f, "{}: [no data]\tchannel: {:?}", self.status(), self.channel())
         }
         else {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -40,9 +40,11 @@ impl SMFReader {
         let tracks = (header[10] as u16) << 8 | header[11] as u16;
         let division = (header[12] as i16) << 8 | header[13] as i16;
 
-        Ok(SMF { format: format,
-                 tracks: Vec::with_capacity(tracks as usize),
-                 division: division } )
+        Ok(SMF {
+            format,
+            tracks: Vec::with_capacity(tracks as usize),
+            division,
+        })
     }
 
     fn next_event(reader: &mut dyn Read, laststat: u8, was_running: &mut bool) -> Result<TrackEvent,SMFError> {
@@ -156,9 +158,9 @@ impl SMFReader {
             }
         }
         Ok(Track {
-            copyright: copyright,
-            name: name,
-            events: res
+            copyright,
+            name,
+            events: res,
         })
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -181,7 +181,7 @@ impl SMFReader {
             if (next & cont_mask) == 0 {
                 break;
             }
-            res = res << 7;
+            res <<= 7;
         }
         Ok(res)
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,7 +21,7 @@ pub fn note_num_to_name(num: u32) -> String {
 /// Read a single byte from a Reader
 pub fn read_byte(reader: &mut dyn Read) -> Result<u8,Error> {
     let mut b = [0; 1];
-    reader.read(&mut b)?;
+    reader.read_exact(&mut b)?;
     Ok(b[0])
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@
 use std::iter;
 use std::io::{Read,Error,ErrorKind};
 
-static NSTRS: &'static str = "C C#D D#E F F#G G#A A#B ";
+static NSTRS: &str = "C C#D D#E F F#G G#A A#B ";
 
 /// convert a midi note number to a name
 pub fn note_num_to_name(num: u32) -> String {

--- a/src/util.rs
+++ b/src/util.rs
@@ -74,7 +74,7 @@ pub fn latin1_decode(s: &[u8]) -> String {
         Ok(s) => s,
         Err(_) => match str::from_utf8(s) {
             Ok(s) => s.to_string(),
-            Err(_) => format!("[invalid string data]"),
+            Err(_) => "[invalid string data]".to_string(),
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,10 +7,10 @@ static NSTRS: &str = "C C#D D#E F F#G G#A A#B ";
 
 /// convert a midi note number to a name
 pub fn note_num_to_name(num: u32) -> String {
-    let oct = (num as f32 /12 as f32).floor()-1.0;
+    let oct = (num as f32 / 12_f32).floor()-1.0;
     let nmt = ((num%12)*2) as usize;
     let slice =
-        if NSTRS.as_bytes()[nmt+1] == ' ' as u8{
+        if NSTRS.as_bytes()[nmt+1] == b' ' {
             &NSTRS[nmt..(nmt+1)]
         } else {
             &NSTRS[nmt..(nmt+2)]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -114,12 +114,12 @@ impl SMFWriter {
     }
 
     fn write_event(&self, vec: &mut Vec<u8>, event: &Event, length: &mut u32, saw_eot: &mut bool) {
-        match event {
-            &Event::Midi(ref midi) => {
+        match *event {
+            Event::Midi(ref midi) => {
                 vec.extend(midi.data.iter());
                 *length += midi.data.len() as u32;
             }
-            &Event::Meta(ref meta) => {
+            Event::Meta(ref meta) => {
                 vec.push(0xff); // indicate we're writing a meta event
                 vec.push(meta.command as u8);
                 // +2 on next line for the 0xff and the command byte we just wrote

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -81,7 +81,7 @@ impl SMFWriter {
         let val_mask = 0x7F as u64;
         loop {
             let mut to_write = (cur & val_mask) as u8;
-            cur = cur >> 7;
+            cur >>= 7;
             if continuation {
                 // we're writing a continuation byte, so set the bit
                 to_write |= cont_mask;
@@ -147,7 +147,7 @@ impl SMFWriter {
             let lbyte = (*length & 0xFF) as u8;
             // 7-i because smf is big endian and we want to put this in bytes 4-7
             vec[7-i] = lbyte;
-            *length = (*length)>>8;
+            *length >>= 8;
         }
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -167,13 +167,10 @@ impl SMFWriter {
         let mut cur_time: u64 = 0;
         let mut saw_eot = false;
 
-        match name {
-            Some(n) => {
-                let namemeta = Event::Meta(MetaEvent::sequence_or_track_name(n));
-                length += SMFWriter::write_vtime(0,&mut vec).unwrap();
-                self.write_event(&mut vec, &namemeta, &mut length, &mut saw_eot);
-            }
-            None => {}
+        if let Some(n) = name {
+            let namemeta = Event::Meta(MetaEvent::sequence_or_track_name(n));
+            length += SMFWriter::write_vtime(0,&mut vec).unwrap();
+            self.write_event(&mut vec, &namemeta, &mut length, &mut saw_eot);
         }
 
         for ev in track {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -35,7 +35,7 @@ impl SMFWriter {
     pub fn new_with_division(ticks: i16) -> SMFWriter {
         SMFWriter {
             format: 1,
-            ticks: ticks,
+            ticks,
             tracks: Vec::new(),
         }
     }
@@ -45,7 +45,7 @@ impl SMFWriter {
     pub fn new_with_division_and_format(format: SMFFormat, ticks: i16) -> SMFWriter {
         SMFWriter {
             format: format as u16,
-            ticks: ticks,
+            ticks,
             tracks: Vec::new(),
         }
     }


### PR DESCRIPTION
See included commits for commentary on particular lints that this is resolving.

This continues toward bringing this library up to date with Rust style (https://github.com/RustAudio/rimd/issues/16)