### PR TITLE
Fix bug in absolute MIDI event writing

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -213,7 +213,7 @@ impl SMFBuilder {
         let vec = track.map(|bev| {
             assert!(bev.time >= cur_time);
             let vtime = bev.time - cur_time;
-            cur_time = vtime;
+            cur_time = bev.time;
             TrackEvent {
                 vtime: vtime,
                 event: bev.event.clone(),


### PR DESCRIPTION
Calculating relative `vtime` when writing `AbsoluteEvent`s had a bug that caused the `vtime` to be incorrectly incremented.  This produced invalid event times in generated MIDI files.

`bev.time` is an *absolute* time in this case since it is from `AbsoluteEvent`, so `cur_time` should be set to it rather than `vtime` which can cause it to move backwards invalidly.